### PR TITLE
docs: Add naming conventions doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -1,0 +1,9 @@
+# Naming Conventions
+
+## InstructLab - The Overall Project Name
+
+* `instructlab` - in URLs, no hyphen
+* `instruct-lab` - in URLs if `instructlab` is not available for some reason
+  (like Slack)
+* `InstructLab` - CamelCase when referring to the name of the overall project.
+* Never `Instruct Lab` with a space.


### PR DESCRIPTION
Start by documenting how we refer to the overall project name,
InstructLab.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
