### PR TITLE
CI: Harden GitHub action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# GitHub Dependabot configuration file
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,25 +6,43 @@ on:
     branches:
       - "main"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
   pull_request:
     branches:
       - "main"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
+
+env:
+  LC_ALL: en_US.UTF-8
 
 defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download actionlint
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Checkout"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+
+      - name: "Download actionlint"
         id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.27
-      - name: Check workflow files
-        run: PATH=".:$PATH" actionlint -color
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/2d26fef7e97b8ab345791f5ade3252da47d083e3/scripts/download-actionlint.bash)
+
+      - name: "Check workflow files"
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/actionlint.json"
+          ${{ steps.get_actionlint.outputs.executable }} -color

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,23 +1,46 @@
-name: docs
+# SPDX-License-Identifier: Apache-2.0
+
+name: Lint Markdown documents
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
     paths:
       - '**/*.md'
       - '.markdownlint-cli2.yaml'
+      - '.github/workflows/docs.yml' # This workflow
   pull_request:
-    branches: ["main"]
+    branches:
+      - "main"
     paths:
       - '**/*.md'
       - '.markdownlint-cli2.yaml'
+      - '.github/workflows/docs.yml' # This workflow
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: markdownlint-cli2-action
-        uses: DavidAnson/markdownlint-cli2-action@v15
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: "Checkout"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - name: "Check Markdown documents"
+        uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16.0.0
         with:
           globs: '**/*.md'

--- a/.github/workflows/matchers/actionlint.json
+++ b/.github/workflows/matchers/actionlint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,10 +3,25 @@
 name: Spellcheck
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches:
+      - "main"
     paths:
       - '**.md'
+      - '.github/workflows/spellcheck.yml' # This workflow
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - '**.md'
+      - '.github/workflows/spellcheck.yml' # This workflow
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
 
 permissions:
   contents: read
@@ -16,7 +31,15 @@ jobs:
     name: Spellcheck (en_US)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Checkout"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.35.0
+        uses: rojopolis/spellcheck-github-actions@dbd2f1da869c05ad874fffeb6fe1ed50cd1a6e98 # v0.36.0

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 config:
   line-length: false
   no-emphasis-as-header: false
@@ -8,6 +10,7 @@ config:
 globs:
   - "**/*.md"
 ignores:
+  - ".github/**"
   - ".tox/**"
   - "venv/**"
   - ".venv/**"

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -1,4 +1,3 @@
-
 # SPDX-License-Identifier: Apache-2.0
 
 matrix:
@@ -9,7 +8,7 @@ matrix:
     camel-case: true
     mode: markdown
   sources:
-  - "**/*.md|!REVIEWERS.md|!build/**|!.tox/**"
+  - "**/*.md|!.tox/**"
   dictionary:
     wordlists:
     - .spellcheck-en-custom.txt

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ endif
 .PHONY: md-lint
 md-lint: ## Lint markdown files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[MD LINT]"
-	$(CMD_PREFIX) podman run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:v0.12.1 > /dev/null
+	$(CMD_PREFIX) podman run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:latest > /dev/null


### PR DESCRIPTION
We use SHAs instead of tag names to refer to action versions. Dependabot will help us manage the SHAs.

Update permissions to minimum necessary.

Add harden-runner to monitor egress of action. After some time, we can tighten the egress to limit hosts/ports.