### PR TITLE
mergify: automatically apply backend label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+- name: label-backend
+  description: Automatically apply backend label
+  conditions:
+    - or:
+      - files~=docs/backend/.*
+  actions:
+    label:
+      add:
+        - backend


### PR DESCRIPTION
Automatically apply the `backend` label to any PR that touches a file
under the `docs/backend` directory.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
