### PR TITLE
Update trusted providers of github actions

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -63,8 +63,8 @@ LLM
 llms
 LLVM
 lora
-md
 Markdownlint
+md
 Mergify
 Merlinite
 mimimum
@@ -74,8 +74,8 @@ MLX
 mlx
 NVidia
 Nvidia
-ollama
 Ollama
+ollama
 orchestrator
 ots
 Pareja
@@ -104,12 +104,13 @@ RX
 safetensors
 Salawu
 SDG
-Sigstore
 sdg
 sexualized
 SHA
+Shellcheck
 Shivchander
 Signoff
+Sigstore
 Srivastava
 subdirectory
 Sudalairaj

--- a/docs/github-actions-providers.md
+++ b/docs/github-actions-providers.md
@@ -9,6 +9,9 @@
 * `rojopolis/spellcheck-github-actions@*` - Spellcheck action
 * `sigstore/gh-action-sigstore-python@*` - Sigstore Python action
 * `step-security/harden-runner@*` - Harden Runner action
+* `ludeeus/action-shellcheck@*` - Shellcheck action
+* `hynek/build-and-inspect-python-package@*` - Build and inspect Python package action
+* `andstor/file-existence-action@*` - File existence action
 
 ## Denied Providers
 


### PR DESCRIPTION
Based on
https://github.com/instructlab/dev-docs/blob/main/docs/github-actions-use-policy.md#trusted-providers-of-github-actions, update the trusted providers of instructlab.

Related to https://github.com/instructlab/instructlab/issues/1218