### PR TITLE
stalebot: reduce amount of time for PR to turn stale

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had activity within 90 days.
+            This issue has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-issue-message: >
             This issue has been automatically closed due to inactivity. Please feel free to reopen if you feel it is still relevant!
@@ -44,9 +44,9 @@ jobs:
           days-before-issue-close: 30
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had activity within 90 days.
-            It will be automatically closed if no further activity occurs within 30 days.
+            This pull request has been automatically marked as stale because it has not had activity within 30 days.
+            It will be automatically closed if no further activity occurs within 7 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!
-          days-before-pr-stale: 60
-          days-before-pr-close: 30
+          days-before-pr-stale: 30
+          days-before-pr-close: 7


### PR DESCRIPTION
We have lots of Dev Docs that get abandoned by their authors. This leads to confusion in the org as to what is actual policy and what is proposed. If a WIP Dev Doc is inactive, it should be closed sooner rather than later.

I have left issues alone but fixed a typo in the text.