### PR TITLE
feat: communcation channels to include discord

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -42,6 +42,8 @@ Communication among the group occurs in the following ways:
   the [InstructLab Community
   Calendar](https://calendar.google.com/calendar/embed?src=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f%40group.calendar.google.com).
 
+- **Discord**: The group has various channels for corresponding components such as `#core`, `#sdg`, `#sdg`, `#eval`, and `#infra`, which can all be found in the [InstructLab Discord](https://instructlab.ai/discord).
+
 - **Slack**: The group uses the `#backend` channel in the InstructLab Slack.
 
 - **Mailing Lists**: There is a [development mailing

--- a/docs/library-release-strategy.md
+++ b/docs/library-release-strategy.md
@@ -33,4 +33,4 @@ following tenants remain consistent:
 1. Packages **must** have GitHub tagged releases named `vX.Y.Z`
 1. Packages **must** use release branches for Y-Streams of the form `release-vX.Y`
 1. Packages **must** maintain a `CHANGELOG.md`
-1. Maintainer teams **must** publicly communicate Y-Stream releases through official InstructLab channels such as Slack or Mailing Lists. Z-Stream release communication is up to Maintainer discretion.
+1. Maintainer teams **must** publicly communicate Y-Stream releases through official InstructLab channels such as Discord, Slack or Mailing Lists. Z-Stream release communication is up to Maintainer discretion.


### PR DESCRIPTION
Due to the addition of Discord as a communication medium for the InstructLab community,
we plan for discussions to take place (including regarding components). This commit
updates that expectation to include Discord where appropriate.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>