### PR TITLE
Remove requirement to use harden-runner action

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -29,11 +29,6 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: "Harden Runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - name: "Checkout"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,10 +32,6 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: "Harden Runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - name: "Checkout"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -31,11 +31,6 @@ jobs:
     name: Spellcheck (en_US)
     runs-on: ubuntu-latest
     steps:
-      - name: "Harden Runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-        with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - name: "Checkout"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -23,14 +23,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: "Harden Runner"
-        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-
       - name: "Stale Action"
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/docs/github-actions-providers.md
+++ b/docs/github-actions-providers.md
@@ -10,7 +10,6 @@
 * `pypa/*@*` - Python Packaging actions
 * `rojopolis/spellcheck-github-actions@*` - Spellcheck action
 * `sigstore/gh-action-sigstore-python@*` - Sigstore Python action
-* `step-security/harden-runner@*` - Harden Runner action
 * `ludeeus/action-shellcheck@*` - Shellcheck action
 * `hynek/build-and-inspect-python-package@*` - Build and inspect Python package action
 * `andstor/file-existence-action@*` - File existence action

--- a/docs/github-actions-use-policy.md
+++ b/docs/github-actions-use-policy.md
@@ -60,31 +60,3 @@ Allowed providers will include all GitHub created actions (`actions/*`) as well 
 The InstructLab organization's Settings->Actions->General must be configured to allow select actions including actions created by GitHub along with the allowed providers.
 
 Adding actions to the allowed providers or denied providers lists will require approval by the organization maintainers along with updating the organization's settings. This can be done by submitting a Pull Request to modify [`github-actions-providers.md`](github-actions-providers.md).
-
-## Harden the GitHub Action runner
-
-To further increase security, the first step of each job in a workflow must be the [`step-security/harden-runner`](https://github.com/step-security/harden-runner) action.
-This action hardens the action runner by implementing network egress control and some infrastructure security.
-
-```yaml
-- name: "Harden Runner"
-  uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-  with:
-    egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-```
-
-Each execution of the workflow job will produce a report showing endpoints accessed by the job and possible source file overwrites.
-The report will also suggest modifications to the harden-runner action's configuration to further increase security.
-
-```yaml
-- name: "Harden Runner"
-  uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-  with:
-    disable-sudo: true
-    egress-policy: block
-    allowed-endpoints: >
-      github.com:443
-```
-
-Hardening the action runner like this can prevent malicious or misbehaving actions or the misuse of actions from exfiltrating secrets.
-The article [Harden-Runner Defends Against Arbitrary Command Execution in `tj-actions/changed-files` GitHub Action](https://www.stepsecurity.io/blog/defend-against-arbitrary-command-execution-in-tj-actions-changed-files) shows how the misuse of an action could allow an attacker with a well-crafted pull request to exfiltrate secrets.


### PR DESCRIPTION
In all the time it was applied, no single repo cared enough to enable
`block` policy for egress network traffic. All the action did is it
produced churn where we were updating tags for the action to new
versions.

We *could* switch these actions to `block` but I'd rather remove the
requirement if in all this time we haven't seen an actual need.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
